### PR TITLE
s/Lambda/Tools

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,1 +1,1 @@
-markovian-lambda
+markovian-tools

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in markovian-lambda.gemspec
+# Specify your gem's dependencies in markovian-tools.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Markovian::Tools
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/markovian/tools`. To experiment with that code, run `bin/console` for an interactive prompt.
+A set of tools for using the Markovian Markov chain library.
 
-TODO: Delete this and the text above, and describe your gem
+Details to come!
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Markovian::Lambda
+# Markovian::Tools
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/markovian/lambda`. To experiment with that code, run `bin/console` for an interactive prompt.
+Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/markovian/tools`. To experiment with that code, run `bin/console` for an interactive prompt.
 
 TODO: Delete this and the text above, and describe your gem
 
@@ -9,7 +9,7 @@ TODO: Delete this and the text above, and describe your gem
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'markovian-lambda'
+gem 'markovian-tools'
 ```
 
 And then execute:
@@ -18,7 +18,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install markovian-lambda
+    $ gem install markovian-tools
 
 ## Usage
 
@@ -32,7 +32,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/markovian-lambda. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/markovian-tools. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](contributor-covenant.org) code of conduct.
 
 
 ## License

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "markovian/lambda"
+require "markovian/tools"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-markovian-lambda
+markovian-tools
 
 v0.0.1
 ======

--- a/lib/markovian/tools.rb
+++ b/lib/markovian/tools.rb
@@ -1,7 +1,7 @@
-require "markovian/lambda/version"
+require "markovian/tools/version"
 
 module Markovian
-  module Lambda
+  module Tools
     # Your code goes here...
   end
 end

--- a/lib/markovian/tools/tweeter.rb
+++ b/lib/markovian/tools/tweeter.rb
@@ -1,7 +1,7 @@
-require 'markovian/lambda/twitter_config'
+require 'markovian/tools/twitter_config'
 
 module Markovian
-  module Lambda
+  module Tools
     # This class, given a Markovian chain object and a Twitter OAuth token, will tweet out a
     # randomly-generated tweet.
     class Tweeter

--- a/lib/markovian/tools/twitter_config.rb
+++ b/lib/markovian/tools/twitter_config.rb
@@ -2,7 +2,7 @@ require 'twitter'
 require 'yaml'
 
 module Markovian
-  module Lambda
+  module Tools
     class TwitterConfig
       def twitter_client
         Twitter::REST::Client.new do |config|
@@ -20,7 +20,7 @@ module Markovian
       end
 
       def twitter_credential_file_path
-        File.join(Lambda.root, "data/twitter_auth.yml")
+        File.join(Tools.root, "data/twitter_auth.yml")
       end
     end
   end

--- a/lib/markovian/tools/version.rb
+++ b/lib/markovian/tools/version.rb
@@ -1,5 +1,5 @@
 module Markovian
-  module Lambda
+  module Tools
     VERSION = "0.1.0"
   end
 end

--- a/markovian-tools.gemspec
+++ b/markovian-tools.gemspec
@@ -1,17 +1,17 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'markovian/lambda/version'
+require 'markovian/tools/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "markovian-lambda"
-  spec.version       = Markovian::Lambda::VERSION
+  spec.name          = "markovian-tools"
+  spec.version       = Markovian::Tools::VERSION
   spec.authors       = ["Alex Koppel"]
   spec.email         = ["alex@alexkoppel.com"]
 
-  spec.summary       = %q{An AWS Lambda wrapper for the Markovian gem.}
+  spec.summary       = %q{An AWS Tools wrapper for the Markovian gem.}
   spec.description   = spec.summary
-  spec.homepage      = "https://github.com/arsduo/markovian-lambda"
+  spec.homepage      = "https://github.com/arsduo/markovian-tools"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }


### PR DESCRIPTION
This repo was originally created to host code that would publish tweets built by Markovian on AWS Lambda. As that turned out to be more of a pain than expected and the need for more tools for managing chains has arisen, it makes sense to turn this repo into a generalized tools repo. (This might in the future include Lambda support.)
