### PR TITLE
Add Facebook Data Importer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 markovian-tools
 
+v0.2.0
+======
+
+* Add complete spec coverage
+* Add Facebook API data importer
+
 v0.1.0
 ======
 

--- a/lib/markovian/importers/facebook/api_data_downloader.rb
+++ b/lib/markovian/importers/facebook/api_data_downloader.rb
@@ -1,0 +1,62 @@
+require 'markovian/tools/facebook_config'
+require 'json'
+
+module Markovian
+  module Importers
+    module Facebook
+      class ApiDataDownloader
+        attr_reader :destination_filename, :debug
+        def initialize(destination_filename, debug: false)
+          @destination_filename = destination_filename
+          @debug = debug
+          @page = nil
+        end
+
+        def read_from_api
+          print "Reading from Facebook" if debug
+          with_output_file do
+            read_pages
+          end
+        end
+
+        protected
+
+        def read_pages
+          while current_page = get_earlier_posts
+            current_page.each do |post|
+              output_file.puts(post.to_json)
+            end
+            print "." if debug
+          end
+          puts "done!" if debug
+        end
+
+        def get_earlier_posts
+          @page = if @page
+            @page.next_page
+          else
+            api.get_connection("me", "feed")
+          end
+        end
+
+        def with_output_file
+          begin
+            # open up one copy of the file that we can use to write
+            # it'll be closed afterward; another copy can be opened by the user if desired.
+            yield
+          ensure
+            output_file.close
+          end
+        end
+
+        def output_file
+          @output_file ||= File.open(destination_filename, "w+")
+        end
+
+        def api
+          Tools::FacebookConfig.new.facebook_client
+        end
+      end
+    end
+  end
+end

--- a/lib/markovian/tools.rb
+++ b/lib/markovian/tools.rb
@@ -1,8 +1,12 @@
 require 'markovian'
 require "markovian/tools/version"
+#
+# Twitter
 require "markovian/importers/tweeter/csv_importer"
 require "markovian/publishers/tweeter"
-require "markovian/tools/facebook_config"
+
+# Facebook
+require "markovian/importers/facebook/api_data_downloader"
 
 module Markovian
   module Tools

--- a/lib/markovian/tools.rb
+++ b/lib/markovian/tools.rb
@@ -2,6 +2,7 @@ require 'markovian'
 require "markovian/tools/version"
 require "markovian/importers/tweeter/csv_importer"
 require "markovian/publishers/tweeter"
+require "markovian/tools/facebook_config"
 
 module Markovian
   module Tools

--- a/lib/markovian/tools/facebook_config.rb
+++ b/lib/markovian/tools/facebook_config.rb
@@ -1,0 +1,23 @@
+require 'koala'
+require 'yaml'
+
+module Markovian
+  module Tools
+    class FacebookConfig
+      def facebook_client
+        Koala::Facebook::API.new(facebook_credentials["access_token"])
+      end
+
+      protected
+
+      def facebook_credentials
+        @facebook_credentials ||= YAML.load_file(facebook_credential_file_path)
+      end
+
+      def facebook_credential_file_path
+        File.join(Tools.root, "data/facebook_auth.yml")
+      end
+    end
+  end
+end
+

--- a/lib/markovian/tools/version.rb
+++ b/lib/markovian/tools/version.rb
@@ -1,5 +1,5 @@
 module Markovian
   module Tools
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/markovian-tools.gemspec
+++ b/markovian-tools.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency     "markovian"
   spec.add_runtime_dependency     "twitter"
+  spec.add_runtime_dependency     "koala"
   spec.add_runtime_dependency     "warbler"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/fixtures/data/facebook_auth.yml
+++ b/spec/fixtures/data/facebook_auth.yml
@@ -1,0 +1,1 @@
+access_token: foobark

--- a/spec/markovian-tools/importers/facebook/api_data_downloader_spec.rb
+++ b/spec/markovian-tools/importers/facebook/api_data_downloader_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+module Markovian
+  module Importers
+    module Facebook
+      RSpec.describe ApiDataDownloader do
+        let(:api) { double(Koala::Facebook::API) }
+        let(:destination_path) { "/tmp/markovian-test" }
+        let(:downloader) { ApiDataDownloader.new(destination_path) }
+
+        before :each do
+          allow_any_instance_of(Tools::FacebookConfig).to receive(:facebook_client).and_return(api)
+        end
+
+        describe "#read_from_api" do
+          let(:page1) { Koala::Facebook::API::GraphCollection.new({"data" => [{"a" => 2}, {"b" => 3}]}, api) }
+          let(:page2) { Koala::Facebook::API::GraphCollection.new({"data" => [{"c" => 4}]}, api) }
+          let(:contents) { File.readlines(destination_path).map(&:chomp) }
+          let(:expected) { (page1 + page2).map(&:to_json) }
+
+          before :each do
+            allow(api).to receive(:get_connection).with("me", "feed").and_return(page1)
+            allow(page1).to receive(:next_page).and_return(page2)
+            allow(page2).to receive(:next_page).and_return(nil)
+          end
+
+          it "writes the data to the desired file" do
+            downloader.read_from_api
+            expect(contents).to eq(expected)
+          end
+
+          it "overwrites the file if called again" do
+            downloader.read_from_api
+            new_downloader = ApiDataDownloader.new(destination_path)
+            new_downloader.read_from_api
+            expect(contents).to eq(expected)
+          end
+
+          it "does not log by default" do
+            expect_any_instance_of(Kernel).not_to receive(:puts)
+            downloader.read_from_api
+          end
+
+          it "will log if appropriate" do
+            expect_any_instance_of(Kernel).to receive(:puts)
+            downloader = ApiDataDownloader.new(destination_path, debug: true)
+            downloader.read_from_api
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/markovian-tools/tools/facebook_config_spec.rb
+++ b/spec/markovian-tools/tools/facebook_config_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+module Markovian
+  module Tools
+    RSpec.describe FacebookConfig do
+      describe "#facebook_client" do
+        let(:config) { FacebookConfig.new }
+
+        before :each do
+          # Use the data in the fixtures directory, not the real Twitter auth
+          root = Tools.root
+          allow(Tools).to receive(:root).and_return(
+            File.join(root, "spec/fixtures/")
+          )
+        end
+
+        it "returns a Koala::Facebook::API with the right config" do
+          client = config.facebook_client
+          expect(client.access_token).to eq("foobark")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Unlike Twitter, Facebook does not provide a machine-readable data archive, but they do offer API access all the way back to 2015. This pull request adds a Koala-based Facebook API data importer to save all the posts in an account down to a local file; a future pull request will add an importer (similar to the Twitter one) that will add to a Markovian::Chain all the post text and comments made by the user.
